### PR TITLE
Add Pub/Sub setup documentation and example script

### DIFF
--- a/docs/pubsub_create_resources.py
+++ b/docs/pubsub_create_resources.py
@@ -1,0 +1,44 @@
+"""Example script that creates Google Cloud Pub/Sub resources using the Python client library.
+
+The script assumes that the Google Cloud CLI has been installed, `gcloud init` has been run to
+select a project, and Application Default Credentials are available (via
+`gcloud auth application-default login`).
+
+Replace the placeholder values in the `PROJECT_ID`, `TOPIC_ID`, and `SUBSCRIPTION_ID` constants
+with identifiers that match your Google Cloud project before running the script.
+"""
+
+from google.cloud import pubsub_v1
+
+PROJECT_ID = "your-project-id"
+TOPIC_ID = "demo-topic"
+SUBSCRIPTION_ID = "demo-subscription"
+
+def main() -> None:
+    """Create a topic and a pull subscription if they do not already exist."""
+    publisher_client = pubsub_v1.PublisherClient()
+    subscriber_client = pubsub_v1.SubscriberClient()
+
+    topic_path = publisher_client.topic_path(PROJECT_ID, TOPIC_ID)
+    subscription_path = subscriber_client.subscription_path(PROJECT_ID, SUBSCRIPTION_ID)
+
+    try:
+        publisher_client.create_topic(request={"name": topic_path})
+        print(f"Created topic: {topic_path}")
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        print(f"Topic may already exist or creation failed: {exc}")
+
+    try:
+        subscriber_client.create_subscription(
+            request={
+                "name": subscription_path,
+                "topic": topic_path,
+            }
+        )
+        print(f"Created subscription: {subscription_path}")
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        print(f"Subscription may already exist or creation failed: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/pubsub_setup.md
+++ b/docs/pubsub_setup.md
@@ -1,0 +1,49 @@
+# Google Cloud Pub/Sub Setup Guide
+
+This document summarizes the steps required to configure the Google Cloud CLI, authenticate,
+and install the Pub/Sub client library before creating resources via Python. These commands
+were not executed in this environment because they require interactive authentication.
+
+## 1. Install the Google Cloud CLI
+
+```bash
+curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-458.0.1-linux-x86_64.tar.gz
+tar -xf google-cloud-cli-458.0.1-linux-x86_64.tar.gz
+./google-cloud-sdk/install.sh
+```
+
+After installation, ensure the `gcloud` binary is on your `PATH` by sourcing the initialization script:
+
+```bash
+source ~/google-cloud-sdk/path.bash.inc
+```
+
+## 2. Initialize the CLI
+
+Authenticate and select the desired project:
+
+```bash
+gcloud init
+```
+
+Follow the prompts in your browser to sign in and choose the active project.
+
+## 3. Configure Application Default Credentials
+
+```bash
+gcloud auth application-default login
+```
+
+This command opens a browser to complete the OAuth flow. When it finishes, Application Default Credentials
+are stored in `~/.config/gcloud/application_default_credentials.json`.
+
+## 4. Install the Pub/Sub Client Library for Python
+
+```bash
+python -m pip install --upgrade google-cloud-pubsub
+```
+
+## 5. Use the Library to Create Pub/Sub Resources
+
+See [pubsub_create_resources.py](./pubsub_create_resources.py) for a complete example that creates a topic
+and subscription using the authenticated credentials.


### PR DESCRIPTION
## Summary
- add step-by-step instructions for installing the Google Cloud CLI, authenticating, and installing the Pub/Sub client
- provide a Python example script that creates a topic and subscription using the Pub/Sub client library

## Testing
- python -m compileall docs/pubsub_create_resources.py

------
https://chatgpt.com/codex/tasks/task_e_68d72b118a08832ca6e0b615ac725b0c